### PR TITLE
Bugfix/silverstripe 4 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This module provides an easy way to build such tree and to add it to a page as a
 
 ## Requirements
 
-* SilverStripe 3.1
+* SilverStripe 4.x
 * (dnadesign/silvertsripe-elemental)[https://github.com/dnadesign/silverstripe-elemental]
 
 ## Screenshots

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   },
   "require": {
     "dnadesign/silverstripe-elemental": ">=3",
-    "silvershop/silverstripe-hasonefield": "3.x-dev"
+    "silvershop/silverstripe-hasonefield": "3.x-dev",
+    "unclecheese/display-logic": "^2.0"
   }
 }

--- a/src/Model/DecisionTreeAnswer.php
+++ b/src/Model/DecisionTreeAnswer.php
@@ -49,8 +49,10 @@ class DecisionTreeAnswer extends DataObject
             if ($this->ResultingStep()->exists()) {
                 array_push($availableStepsID, $this->ResultingStepID);
             }
-
-            $steps = DecisionTreeStep::get()->filter('ID', $availableStepsID)->map();
+            $steps = [];
+            if ($availableStepsID) {
+                $steps = DecisionTreeStep::get()->filter('ID', $availableStepsID)->map();
+            }
 
             $stepSelector = HasOneSelectOrCreateField::create(
                 $this, 'ResultingStep', 'If selected, go to', $steps, $this->ResultingStep(), $this
@@ -59,10 +61,10 @@ class DecisionTreeAnswer extends DataObject
             $fields->addFieldsToTab('Root.Main', $stepSelector);
         } else {
             $info = LiteralField::create('info', sprintf(
-                '<p class="message info notice">%s</p>', 
+                '<p class="message info notice">%s</p>',
                 'Save this answer in order to add a following step.'
             ));
-            
+
             $fields->addFieldToTab('Root.Main', $info);
         }
 
@@ -144,7 +146,7 @@ class DecisionTreeAnswer extends DataObject
     public function CMSAddStepLink()
     {
         $link = Controller::join_links(
-            $this->CMSEditLink(), 
+            $this->CMSEditLink(),
             'itemEditForm/field/ResultingStep/item/new'
         );
 

--- a/src/Model/ElementDecisionTree.php
+++ b/src/Model/ElementDecisionTree.php
@@ -69,7 +69,7 @@ class ElementDecisionTree extends BaseElement
         return Controller::join_links(
             singleton(CMSPageEditController::class)->Link('EditForm'),
             $page->ID,
-            'field/ElementArea/item/',
+            'field/ElementalArea/item/',
             $this->ID,
             'ItemEditForm/field/FirstStep/item',
             $this->FirstStep()->ID


### PR DESCRIPTION
Small changes made to get module working in Silverstripe 4

AC: able to use module to create a new decision tree without any errors.
AC: CMS user is able to navigate decision tree using the 'Tree' view