### PR TITLE
Prevent CMS author selecting first step as resulting step

### DIFF
--- a/src/Model/DecisionTreeAnswer.php
+++ b/src/Model/DecisionTreeAnswer.php
@@ -2,6 +2,7 @@
 
 namespace DNADesign\SilverStripeElementalDecisionTree\Model;
 
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Control\Controller;
 use SilverStripe\Forms\LiteralField;
@@ -180,5 +181,32 @@ class DecisionTreeAnswer extends DataObject
     public function getRecursiveEditPathForSelf()
     {
         return sprintf('ItemEditForm/field/Answers/item/%s/', $this->ID);
+    }
+
+    /**
+     * Hook before saving the data object.
+     *
+     * @throws \SilverStripe\ORM\ValidationException
+     */
+    protected function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        $this->validateSelectedResultingStep();
+    }
+
+    /**
+     * Validate the step ID selected by CMS user for resulting step and throw exception if invalid.
+     *
+     * @throws \SilverStripe\ORM\ValidationException
+     */
+    protected function validateSelectedResultingStep()
+    {
+        if ($this->ResultingStepID) {
+            $step = DecisionTreeStep::get()->filter('ID', $this->ResultingStepID)->first();
+            if ($step instanceof DecisionTreeStep && $step->belongsToElement()) {
+                throw new ValidationException('You can\'t select the first step in the tree as a resulting step.');
+            }
+        }
     }
 }

--- a/src/Model/DecisionTreeStep.php
+++ b/src/Model/DecisionTreeStep.php
@@ -168,11 +168,20 @@ class DecisionTreeStep extends DataObject
     /**
     * Return the DecisionAnswer rsponsible for displaying this step
     *
-    * @return DecisionTreeAnswer
+    * @return DecisionTreeAnswer|null
     */
     public function getParentAnswer()
     {
-        return DecisionTreeAnswer::get()->filter('ResultingStepID', $this->ID)->First();
+        // Get db ID of the first step in the tree
+        $firstStepId = $this->ParentElement()->FirstStepID;
+
+        // Return the answer only if the selected resulting step id of the doesn't match the first step.
+        // First step can't be used as resulting step
+        if ($firstStepId > 0 && $firstStepId !== $this->ID) {
+            return DecisionTreeAnswer::get()->filter('ResultingStepID', $this->ID)->First();
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
CMS Author is able to select the first step as a resulting step. This causes an infinite loop and breaks CMS and public site page load.

The PR updates the module to throw a validation exception before saving an answer if the first step is selected to prevent this error. And ensure the Parent Answer in the step data object does not return the first step if this selection happened for whatever reason.