### PR TITLE
FIX: Issue where Decisiontrees are created outside ElementalArea context

### DIFF
--- a/src/Model/ElementDecisionTree.php
+++ b/src/Model/ElementDecisionTree.php
@@ -7,6 +7,7 @@ use DNADesign\SilverStripeElementalDecisionTree\Forms\HasOneSelectOrCreateField;
 use DNADesign\SilverStripeElementalDecisionTree\Forms\DecisionTreeStepPreview;
 use SilverStripe\Control\Controller;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
+use SilverStripe\Forms\LiteralField;
 
 class ElementDecisionTree extends BaseElement
 {
@@ -38,18 +39,27 @@ class ElementDecisionTree extends BaseElement
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
+        $fields->removeByName('FirstStepID');
 
         $introduction = $fields->dataFieldByName('Introduction');
         $introduction->setRows(4);
 
-        $fields->removeByName('FirstStepID');
-        $stepSelector = HasOneSelectOrCreateField::create(
-            $this, 'FirstStep', 'First Step', DecisionTreeStep::get_initial_steps()->map(), $this->FirstStep(), $this
-        );
+        if ($this->IsInDB()) {
+            $stepSelector = HasOneSelectOrCreateField::create(
+                $this, 'FirstStep', 'First Step', DecisionTreeStep::get_initial_steps()->map(), $this->FirstStep(), $this
+            );
 
-        $fields->addFieldToTab('Root.Main', $stepSelector);
+            $fields->addFieldToTab('Root.Main', $stepSelector);
 
-        $fields->addFieldToTab('Root.Tree', DecisionTreeStepPreview::create('Tree', $this->FirstStep()));
+            $fields->addFieldToTab('Root.Tree', DecisionTreeStepPreview::create('Tree', $this->FirstStep()));
+        } else {
+            $info = LiteralField::create('info', sprintf(
+                '<p class="message info notice">%s</p>',
+                'Save this decision tree in order to add the first step.'
+            ));
+
+            $fields->addFieldToTab('Root.Main', $info);
+        }
 
         return $fields;
     }


### PR DESCRIPTION
ElementalAreas create the element and save it in the database before attempting to render the edit form. However when creating blocks in other contexts such as a gridfield in a custom ModelAdmin, it tries to render the HasOneSelectOrCreateField before the Element is saved in the database, leading to an error:

![image](https://user-images.githubusercontent.com/10215604/189585080-383a3b8e-14f4-4195-96a5-8537fbfd31da.png)

**Steps to reproduce**

- Create custom model admin with ElementDecisionTrees
<details>
  <summary>Example code</summary>

```php
<?php

namespace App\CustomModel;

use DNADesign\SilverStripeElementalDecisionTree\Model\ElementDecisionTree;
use SilverStripe\Admin\ModelAdmin;

class CustomModelAdmin extends ModelAdmin
{
    private static $managed_models = [
        ElementDecisionTree::class,
    ];

    private static $url_segment = 'CustomModel';

    private static $menu_title = 'CustomModel';
}
```

</details>

- Add a Decision tree Element
- Create a DecisionTreeStep
- Navigate back to the Model admin and create a new Decision tree Element
- Error occurs 