### PR TITLE
Add YML config to enable/disable module JS files

### DIFF
--- a/src/Extensions/ElementDecisionTreeController.php
+++ b/src/Extensions/ElementDecisionTreeController.php
@@ -5,6 +5,7 @@ namespace DNADesign\SilverStripeElementalDecisionTree\Extensions;
 use DNADesign\SilverStripeElementalDecisionTree\Model\DecisionTreeAnswer;
 use DNADesign\SilverStripeElementalDecisionTree\Model\DecisionTreeStep;
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extension;
 use SilverStripe\Model\ArrayData;
 use SilverStripe\ORM\FieldType\DBHTMLText;
@@ -12,20 +13,40 @@ use SilverStripe\View\Requirements;
 
 class ElementDecisionTreeController extends Extension
 {
+    use Configurable;
+
+    /**
+     * Whether or not to include jquery included in the module.
+     *
+     * @config
+     */
+    private static bool $include_jquery = true;
+
+    /**
+     * Whether or not to include the javascript included in the module.
+     *
+     * @config
+     */
+    private static bool $include_default_js = true;
+
     private static array $allowed_actions = [
         'getNextStepForAnswer',
     ];
 
     public function onAfterInit(): void
     {
-        Requirements::javascript(
-            'dnadesign/silverstripe-elemental-decisiontree:javascript/jquery.min.js'
-        );
+        if (self::config()->get('include_jquery')) {
+            Requirements::javascript(
+                'dnadesign/silverstripe-elemental-decisiontree:javascript/jquery.min.js'
+            );
+        }
 
-        Requirements::javascript(
-            'dnadesign/silverstripe-elemental-decisiontree:javascript/decision-tree.src.js',
-            ['defer' => true]
-        );
+        if (self::config()->get('include_default_js')) {
+            Requirements::javascript(
+                'dnadesign/silverstripe-elemental-decisiontree:javascript/decision-tree.src.js',
+                ['defer' => true]
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Add YML configuration to enable/disable the JS files. This should resolve https://github.com/dnadesign/silverstripe-elemental-decisiontree/issues/23

The included jQuery also break the CMS interface because the extension is applied to `Controller` which is applied in the admin because `AdminController` extends it too.

```
SilverStripe\Control\Controller:
  extensions:
    - DNADesign\SilverStripeElementalDecisionTree\Extensions\ElementDecisionTreeController
```