### PR TITLE
Fix nested ARIA live regions and convert to vanilla JS

### DIFF
--- a/javascript/decision-tree.src.js
+++ b/javascript/decision-tree.src.js
@@ -1,69 +1,240 @@
-(function($) {
+/**
+ * Decision Tree - Accessible Interactive Component
+ *
+ * Vanilla JS conversion of original jQuery implementation.
+ * Adds ARIA live region announcements for screen readers.
+ */
+(function() {
+    'use strict';
 
-    $(document).ready(function() {
+    /**
+     * Announce a message to screen readers via the live region
+     * @param {HTMLElement} tree - The decision tree container
+     * @param {string} message - Message to announce
+     */
+    function announce(tree, message) {
+        const announcer = tree.querySelector('.decisiontree-announcer');
+        if (announcer) {
+            // Clear first, then set - ensures announcement even if same text
+            announcer.textContent = '';
+            // Small delay ensures screen readers pick up the change
+            setTimeout(() => {
+                announcer.textContent = message;
+            }, 50);
+        }
+    }
+
+    /**
+     * Extract the question/result title from step HTML for announcements
+     * @param {HTMLElement} stepElement - The step element
+     * @returns {string} - The title text or empty string
+     */
+    function getStepTitle(step) {
+        const titleInner = step.querySelector('.step-title-inner');
+        if (titleInner) {
+            return titleInner.textContent.trim();
+        }
+        const resultTitle = step.querySelector('.step-title');
+        if (resultTitle) {
+            return resultTitle.textContent.trim();
+        }
+        return '';
+    }
+
+    /**
+     * Check if the loaded step is a result (final answer)
+     */
+    function isResultStep(step) {
+        return step.classList.contains('step--result') ||
+                step.getAttribute('data-step-type') === 'result';
+    }
+
+    /**
+     * Serialize form data to URL-encoded string
+     */
+    function serializeForm(form) {
+        var formData = new FormData(form);
+        var params = new URLSearchParams();
+        formData.forEach(function(value, key) {
+            params.append(key, value);
+        });
+        return params.toString();
+    }
+
+    /**
+     * Fade out element then execute callback
+     */
+    function fadeOut(element, callback) {
+        element.style.transition = 'opacity 0.4s ease';
+        element.style.opacity = '0';
+        setTimeout(function() {
+            element.style.display = 'none';
+            if (callback) callback();
+            element.style.display = '';
+            element.style.opacity = '';
+            element.style.transition = '';
+        }, 400);
+    }
+
+    /**
+     * Smooth scroll to element with offset
+     */
+    function scrollToElement(element, offset, callback) {
+        var rect = element.getBoundingClientRect();
+        var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+        var targetTop = rect.top + scrollTop - offset;
+
+        window.scrollTo({
+            top: targetTop,
+            behavior: 'smooth'
+        });
+
+        if (callback) {
+            setTimeout(callback, 500);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
         /**
-        * Submit Step form when selecting an answer
-        * Adds loading animation to empty "nextstep" div
-        * Fetch content via ajax
-        * Insert HTML and update URL
-        */
-        $(document).on( 'change', 'input[name=stepanswerid] ', function() {
-            var form = $(this).parents('form'),
-                step = form.parent('.step'),
-                nextstep_holder = step.find('> .nextstep');
+         * Submit Step form when selecting an answer
+         * Adds loading animation to empty "nextstep" div
+         * Fetch content via ajax
+         * Insert HTML and update URL
+         */
+        document.addEventListener('change', function(event) {
+            var input = event.target;
+            if (input.name !== 'stepanswerid' || input.type !== 'radio') {
+                return;
+            }
 
-                nextstep_holder.html('<div class="spinner-holder"><div class="spinner"><span class="sr-only">loading</span></div></div>');
-                setTimeout(function() {
-                    nextstep_holder.addClass('loading');
-                }, 100);
+            var form = input.closest('form');
+            if (!form) return;
 
-                $.ajax({
-                    url     : form.attr('action'),
-                    type    : form.attr('method'),
-                    dataType: 'json',
-                    data    : form.serialize(),
-                    success : function( data ) {
-                        nextstep_holder.addClass('new-content-loaded');
-                        nextstep_holder.html(data.html);
+            var step = form.parentElement;
+            if (!step || !step.classList.contains('step')) return;
+
+            var nextstepHolder = step.querySelector(':scope > .nextstep');
+            if (!nextstepHolder) return;
+
+            var tree = step.closest('.decisiontree');
+
+            // Insert spinner HTML
+            nextstepHolder.innerHTML = '<div class="spinner-holder"><div class="spinner"><span class="sr-only">loading</span></div></div>';
+
+            // Announce loading to screen readers
+            announce(tree, 'Loading next question, please wait.');
+
+            // After 100ms, add loading class (matches original jQuery timing)
+            setTimeout(function() {
+                nextstepHolder.classList.add('loading');
+            }, 100);
+
+            // Make AJAX request
+            var xhr = new XMLHttpRequest();
+            xhr.open(form.getAttribute('method') || 'POST', form.getAttribute('action'), true);
+            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+            xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+
+            xhr.onload = function() {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    try {
+                        var data = JSON.parse(xhr.responseText);
+
+                        // Add new-content-loaded class, insert HTML, update URL (matches original)
+                        nextstepHolder.classList.add('new-content-loaded');
+                        nextstepHolder.innerHTML = data.html;
                         window.history.pushState(null, null, data.nexturl);
-                    },
-                    error   : function( xhr, err ) {
-                        nextstep_holder.html(xhr.responseText);
+
+                        // Announce the new content to screen readers
+                        var newStep = nextstepHolder.querySelector('.step');
+                        if (newStep) {
+                            var title = getStepTitle(newStep);
+                            if (isResultStep(newStep)) {
+                                announce(tree, 'Result: ' + title);
+                            } else {
+                                var stepNumber = newStep.querySelector('.step-number');
+                                var questionNum = stepNumber ? stepNumber.textContent.trim() : '';
+                                announce(tree, 'Question ' + questionNum + ' ' + title);
+                            }
+                        }
+                    } catch (e) {
+                        nextstepHolder.innerHTML = xhr.responseText;
+                        announce(tree, 'Error loading question. Please reload the page and try again.');
                     }
-                }).always(function() {
-                    setTimeout(function() {
-                        nextstep_holder.removeClass('loading new-content-loaded');
-                    }, 100);
-                });
+                } else {
+                    nextstepHolder.innerHTML = xhr.responseText;
+                    announce(tree, 'Error loading question. Please reload the page and try again.');
+                }
+
+                // Always: after 100ms remove both classes (matches original jQuery .always())
+                setTimeout(function() {
+                    nextstepHolder.classList.remove('loading', 'new-content-loaded');
+                }, 100);
+            };
+
+            xhr.onerror = function() {
+                nextstepHolder.innerHTML = '<p>An error occurred. Please try again.</p>';
+                announce(tree, 'Error loading question. Please reload the page and try again.');
+
+                setTimeout(function() {
+                    nextstepHolder.classList.remove('loading', 'new-content-loaded');
+                }, 100);
+            };
+
+            xhr.send(serializeForm(form));
         });
 
         /**
-        * Handles the restart button
-        * Empties all subsequent steps then
-        * Scroll back to first step then
-        * Reset url to original page url
-        */
-        $(document).on('click', 'button[data-action="restart-tree"]', function() {
-            var button = $(this),
-                firststep = button.parents('.step--first'),
-                radio = firststep.find('input[type="radio"]'),
-                tree = firststep.parents('.ElementDecisionTree');
+         * Handles the restart button
+         * Empties all subsequent steps then
+         * Scroll back to first step then
+         * Reset url to original page url
+         */
+        document.addEventListener('click', function(event) {
+            var button = event.target;
+            if (button.getAttribute('data-action') !== 'restart-tree') {
+                return;
+            }
 
-            if (firststep) {
-                firststep.find('.nextstep').fadeOut(function() {
-                    $(this).html('').show();
-                    radio.prop('checked', false);
+            var firststep = button.closest('.step--first');
+            if (!firststep) return;
 
-                    if ($(tree).length > 0) {
-                        $('html, body').animate({
-                            scrollTop: $(tree).offset().top - 150
-                        }, 500);
+            var radio = firststep.querySelectorAll('input[type="radio"]');
+            var tree = firststep.closest('.decisiontree');
+            var firstLegend = firststep.querySelector('legend.step-legend');
+            var nextstepHolder = firststep.querySelector(':scope > .nextstep');
+
+            if (nextstepHolder) {
+                // Fade out then clear content (matches original jQuery fadeOut)
+                fadeOut(nextstepHolder, function() {
+                    nextstepHolder.innerHTML = '';
+
+                    // Uncheck all radios
+                    radio.forEach(function(r) {
+                        r.checked = false;
+                    });
+
+                    // Announce reset to screen readers
+                    announce(tree, 'Decision tree reset. Starting from the first question.');
+
+                    if (firstLegend) {
+                        // Scroll to the first question's legend
+                        scrollToElement(firstLegend, 150, function() {
+                            // Set focus on the legend for keyboard navigation
+                            if (!firstLegend.getAttribute('tabindex')) {
+                                firstLegend.setAttribute('tabindex', '-1');
+                            }
+                            firstLegend.focus();
+                        });
+                    } else if (tree) {
+                        scrollToElement(tree, 150);
                     }
 
-                    const url = location.protocol + '//' + location.host + location.pathname;
+                    // Reset URL
+                    var url = location.protocol + '//' + location.host + location.pathname;
                     window.history.pushState(null, null, url);
                 });
             }
         });
     });
-})(jQuery);
+})();

--- a/src/Extensions/ElementDecisionTreeController.php
+++ b/src/Extensions/ElementDecisionTreeController.php
@@ -4,6 +4,7 @@ namespace DNADesign\SilverStripeElementalDecisionTree\Extensions;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\View\ArrayData;
+use SilverStripe\View\Requirements;
 use SilverStripe\Core\Extension;
 use DNADesign\SilverStripeElementalDecisionTree\Model\DecisionTreeStep;
 use DNADesign\SilverStripeElementalDecisionTree\Model\DecisionTreeAnswer;
@@ -14,6 +15,20 @@ class ElementDecisionTreeController extends Extension
     private static $allowed_actions = [
         'getNextStepForAnswer'
     ];
+
+    public function onAfterInit()
+    {
+        Requirements::javascript('dnadesign/silverstripe-elemental-decisiontree:javascript/decision-tree.src.js');
+        Requirements::customCSS(
+            <<<CSS
+                .decisiontree .step-options input[type="radio"]:focus + label,
+                .decisiontree .step-options input[type="radio"]:focus-visible + label {
+                    outline: 2px solid currentColor;
+                    outline-offset: 2px;
+                }
+            CSS
+        );
+    }
 
     /**
     * Return the HTMl for the next step to be displayed
@@ -35,7 +50,7 @@ class ElementDecisionTreeController extends Extension
 
         if (!$answer || !$answer->exists()) {
             return $this->owner->httpError(
-                404, 
+                404,
                 $this->renderError('An error has occurred, please reload the page and try again!')
             );
         }
@@ -44,7 +59,7 @@ class ElementDecisionTreeController extends Extension
 
         if (!$nextStep || !$nextStep->exists()) {
             return $this->owner->httpError(
-                404, 
+                404,
                 $this->renderError('An error has occurred, please reload the page and try again!')
             );
         }
@@ -142,7 +157,7 @@ class ElementDecisionTreeController extends Extension
                     <span class="step-title">Sorry!</span>
                     <span class="step-content"><p>%s</p></span>
                 </div>
-            </div>', 
+            </div>',
             $message
         );
     }

--- a/templates/DNADesign/SilverStripeElementalDecisionTree/Model/DecisionTreeStep.ss
+++ b/templates/DNADesign/SilverStripeElementalDecisionTree/Model/DecisionTreeStep.ss
@@ -1,9 +1,9 @@
 <% if $Step.Type == 'Question' %>
-<div class="step<% if $FirstStep.ID == $Step.ID %> step--first<% end_if %>">
+<div class="step<% if $FirstStep.ID == $Step.ID %> step--first<% end_if %>" data-step-id="$Step.ID">
 	<form action="$Controller.Link('getNextStepForAnswer')" method="post" class="step-form">
 		<% with $Step %>
 		<fieldset>
-			<legend class="step-legend <% if $Content %>step-legend--withcontent<% end_if %>">
+			<legend class="step-legend <% if $Content %>step-legend--withcontent<% end_if %>" id="step-legend-{$ID}">
 				<span class="step-title">
 					<span class="step-number">{$PositionInPathway}.</span>
 					<span class="step-title-inner">$Title</span>
@@ -14,8 +14,8 @@
 				<ul class="optionset step-options">
 				<% loop $Answers %>
 					<li>
-						<input id="$ID" class="radio step-option" name="stepanswerid" type="radio" value="$ID"<% if $Top.Controller.getIsAnswerSelected($ID) %> checked<% end_if %> />
-						<label for="$ID">$Title</label>
+						<input id="answer-$ID" class="radio step-option" name="stepanswerid" type="radio" value="$ID" aria-describedby="step-legend-{$Up.ID}"<% if $Top.Controller.getIsAnswerSelected($ID) %> checked<% end_if %> />
+						<label for="answer-$ID">$Title</label>
 					</li>
 				<% end_loop %>
 				</ul>
@@ -24,19 +24,19 @@
 		<% end_with %>
 	</form>
 
-	<div class="nextstep" aria-live="polite">
+	<div class="nextstep">
 		<% if $Controller.getNextStepFromSelectedAnswer($Step.ID) %>
 			<% include DecisionTreeStep Step=$Controller.getNextStepFromSelectedAnswer($Step.ID), Controller=$Controller %>
 		<% end_if %>
 	</div>
 </div>
 <% else %>
-<div class="step step--result" aria-live="polite">
+<div class="step step--result" data-step-id="$Step.ID" data-step-type="result">
 	<% with $Step %>
-		<% if $Title && not $HideTitle %><div class="step-title">$Title</div><% end_if %>
+		<% if $Title && not $HideTitle %><div class="step-title" id="result-title-$ID">$Title</div><% end_if %>
 		<div class="step-content">
 			<% if $Content %>$Content<% end_if %>
-			<button type="button" class="step-button" data-action="restart-tree" data-target="$Top.Controller.ParentController.Link">Start again?</button>
+			<button type="button" class="step-button" data-action="restart-tree" data-target="$Top.Controller.ParentController.Link" aria-label="Start again from the beginning">Start again?</button>
 		</div>
 	<% end_with %>
 </div>

--- a/templates/DNADesign/SilverStripeElementalDecisionTree/Model/ElementDecisionTree.ss
+++ b/templates/DNADesign/SilverStripeElementalDecisionTree/Model/ElementDecisionTree.ss
@@ -1,4 +1,4 @@
-<div class="decisiontree">
+<div class="decisiontree" role="region" aria-label="Decision tree">
 	<div class="decisiontree-header">
 		<% if not $HideTitle %><div class="decisiontree-title">$Title</div><% end_if %>
 		<% if $Introduction %><div class="decisiontree-intro">$Introduction</div><% end_if %>
@@ -7,6 +7,8 @@
 	<div class="decisiontree-main">
 		<% include DNADesign\SilverStripeElementalDecisionTree\Model\DecisionTreeStep Step=$FirstStep, Controller=$Controller %>
 	</div>
+
+	<div class="decisiontree-announcer sr-only" aria-live="polite" aria-atomic="true"></div>
 </div>
 
 <% require javascript("dnadesign/silverstripe-elemental-decisiontree:javascript/decision-tree.src.js") %>


### PR DESCRIPTION
   - Remove jQuery dependency, convert decision-tree.src.js to vanilla JS - Initially use Claude code to convert -test manually
   - Add single ARIA live region announcer for screen reader support
   - Announce loading states, questions, results, and reset events
   - Add data-step-id, aria-describedby on radio inputs for accessibility
   - Add focus outline CSS for radio button labels via Requirements::customCSS
   - Delete bundled jquery.min.js (no longer needed)