### PR TITLE
fix: ES5 compat — replace arrow function for UglifyJS

### DIFF
--- a/javascript/decision-tree.src.js
+++ b/javascript/decision-tree.src.js
@@ -18,7 +18,7 @@
             // Clear first, then set - ensures announcement even if same text
             announcer.textContent = '';
             // Small delay ensures screen readers pick up the change
-            setTimeout(() => {
+            setTimeout(function() {
                 announcer.textContent = message;
             }, 50);
         }


### PR DESCRIPTION
## Summary
- Replaces the single arrow function in `announce()` with an ES5 `function()` expression
- `gulp-uglify` (UglifyJS) in consuming projects can't parse ES6 arrow functions when babel config lookup fails for vendor files