### PR TITLE
fix: replace arrow function with ES5 function for UglifyJS compatibility

### DIFF
--- a/javascript/decision-tree.src.js
+++ b/javascript/decision-tree.src.js
@@ -18,7 +18,7 @@
             // Clear first, then set - ensures announcement even if same text
             announcer.textContent = '';
             // Small delay ensures screen readers pick up the change
-            setTimeout(() => {
+            setTimeout(function() {
                 announcer.textContent = message;
             }, 50);
         }


### PR DESCRIPTION
The arrow function in the announce method breaks gulp-uglify in consuming projects where babel config lookup fails for vendor files.